### PR TITLE
FIX BUG: default value not changed when updating an extrafield using API #33949

### DIFF
--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -1481,7 +1481,7 @@ class Setup extends DolibarrApi
 		}
 
 		$alwayseditable = $request_data['alwayseditable'];
-		$default_value = $request_data['default_value'];
+		$default_value = $request_data['default'];
 		$totalizable = $request_data['totalizable'];
 		$printable = $request_data['printable'];
 		$required = $request_data['required'];

--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -1566,7 +1566,7 @@ class Setup extends DolibarrApi
 		}
 
 		$alwayseditable = $request_data['alwayseditable'];
-		$default_value = $request_data['default_value'];
+		$default_value = $request_data['default'];
 		$totalizable = $request_data['totalizable'];
 		$printable = $request_data['printable'];
 		$required = $request_data['required'];


### PR DESCRIPTION
# FIX #33949 default value not updated like the rest of extrafield when using API
This PR fixes #33949 and makes it possible to use the API to update an extrafield definition